### PR TITLE
Add Python interface for bropt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "bropt"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+name = "bropt"
+crate-type = ["rlib", "cdylib"]
+
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
 

--- a/bropt.py
+++ b/bropt.py
@@ -1,0 +1,30 @@
+"""Python interface for the bropt Brainfuck interpreter.
+
+This module provides a simple wrapper around the `bropt_run` function
+exported by the Rust library. The dynamic library is loaded from the
+`target/release` directory produced by `cargo build --release`.
+"""
+from __future__ import annotations
+
+import ctypes
+from pathlib import Path
+
+_lib_path = Path(__file__).resolve().parent / "target" / "release" / "libbropt.so"
+_lib = ctypes.CDLL(str(_lib_path))
+
+_lib.bropt_run.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.c_ubyte]
+_lib.bropt_run.restype = None
+
+def run(code: str, length: int = 65536, flush: bool = False) -> None:
+    """Run a Brainfuck program.
+
+    Parameters
+    ----------
+    code: str
+        Brainfuck source code.
+    length: int, optional
+        Tape length (default 65536).
+    flush: bool, optional
+        Flush standard output after each output instruction.
+    """
+    _lib.bropt_run(code.encode("utf-8"), length, 1 if flush else 0)

--- a/bropt.py
+++ b/bropt.py
@@ -9,14 +9,23 @@ from __future__ import annotations
 import ctypes
 from pathlib import Path
 
+try:  # optional numpy support
+    import numpy as np
+    _HAS_NUMPY = True
+except Exception:  # pragma: no cover - numpy may be unavailable
+    np = None
+    _HAS_NUMPY = False
+
 _lib_path = Path(__file__).resolve().parent / "target" / "release" / "libbropt.so"
 _lib = ctypes.CDLL(str(_lib_path))
 
-_lib.bropt_run.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.c_ubyte]
-_lib.bropt_run.restype = None
+_lib.bropt_run.argtypes = [ctypes.c_char_p, ctypes.c_size_t, ctypes.c_ubyte, ctypes.c_void_p]
+_lib.bropt_run.restype = ctypes.c_char_p
+_lib.bropt_free_error.argtypes = [ctypes.c_char_p]
+_lib.bropt_free_error.restype = None
 
-def run(code: str, length: int = 65536, flush: bool = False) -> None:
-    """Run a Brainfuck program.
+def run(code: str, length: int = 65536, flush: bool = False, *, as_numpy: bool = False):
+    """Run a Brainfuck program and return the final tape state.
 
     Parameters
     ----------
@@ -26,5 +35,18 @@ def run(code: str, length: int = 65536, flush: bool = False) -> None:
         Tape length (default 65536).
     flush: bool, optional
         Flush standard output after each output instruction.
+    as_numpy: bool, optional
+        Return a :class:`numpy.ndarray` of dtype ``int8`` instead of ``bytes``.
     """
-    _lib.bropt_run(code.encode("utf-8"), length, 1 if flush else 0)
+    buf = (ctypes.c_ubyte * length)()
+    err = _lib.bropt_run(code.encode("utf-8"), length, 1 if flush else 0, ctypes.cast(buf, ctypes.c_void_p))
+    if err:
+        msg = ctypes.string_at(err).decode("utf-8")
+        _lib.bropt_free_error(err)
+        raise RuntimeError(msg)
+    data = bytes(buf)
+    if as_numpy:
+        if not _HAS_NUMPY:
+            raise RuntimeError("numpy is not available")
+        return np.frombuffer(data, dtype=np.uint8).astype(np.int8)
+    return data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,55 @@
 pub mod brainfuck;
 
-use brainfuck::{compile, get_offset, unsafe_run};
-use std::ffi::CStr;
+use brainfuck::{compile, run_result};
+use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_uchar};
+use std::ptr;
 
-/// Execute Brainfuck code through a C-compatible interface.
+/// Execute Brainfuck code through a C-compatible interface and capture tape state.
+///
+/// Returns a null pointer on success or an error string on failure. The caller must
+/// free the returned error string with `bropt_free_error`.
 ///
 /// # Safety
-/// `code` must be a valid null-terminated UTF-8 string.
+/// `code` must be a valid null-terminated UTF-8 string and `out` must be a valid
+/// buffer of at least `length` bytes.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn bropt_run(code: *const c_char, length: usize, flush: c_uchar) {
-    if code.is_null() {
-        return;
+pub unsafe extern "C" fn bropt_run(
+    code: *const c_char,
+    length: usize,
+    flush: c_uchar,
+    out: *mut c_uchar,
+) -> *mut c_char {
+    if code.is_null() || out.is_null() {
+        return CString::new("null pointer").unwrap().into_raw();
     }
     let c_str = unsafe { CStr::from_ptr(code) };
-    if let Ok(code_str) = c_str.to_str() {
-        let prog = compile(code_str);
-        let offset = get_offset(&prog);
-        if flush != 0 {
-            unsafe_run::<true>(prog, length, offset);
-        } else {
-            unsafe_run::<false>(prog, length, offset);
+    let code_str = match c_str.to_str() {
+        Ok(s) => s,
+        Err(_) => return CString::new("invalid utf-8").unwrap().into_raw(),
+    };
+    let prog = match compile(code_str) {
+        Ok(p) => p,
+        Err(e) => return CString::new(e).unwrap().into_raw(),
+    };
+    let result = if flush != 0 {
+        run_result::<true>(prog, length)
+    } else {
+        run_result::<false>(prog, length)
+    };
+    match result {
+        Ok(data) => {
+            unsafe { ptr::copy_nonoverlapping(data.as_ptr(), out, length); }
+            ptr::null_mut()
         }
+        Err(e) => CString::new(e).unwrap().into_raw(),
+    }
+}
+
+/// Free an error string returned by `bropt_run`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bropt_free_error(err: *mut c_char) {
+    if !err.is_null() {
+        unsafe { drop(CString::from_raw(err)); }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,26 @@
+pub mod brainfuck;
+
+use brainfuck::{compile, get_offset, unsafe_run};
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_uchar};
+
+/// Execute Brainfuck code through a C-compatible interface.
+///
+/// # Safety
+/// `code` must be a valid null-terminated UTF-8 string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bropt_run(code: *const c_char, length: usize, flush: c_uchar) {
+    if code.is_null() {
+        return;
+    }
+    let c_str = unsafe { CStr::from_ptr(code) };
+    if let Ok(code_str) = c_str.to_str() {
+        let prog = compile(code_str);
+        let offset = get_offset(&prog);
+        if flush != 0 {
+            unsafe_run::<true>(prog, length, offset);
+        } else {
+            unsafe_run::<false>(prog, length, offset);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,13 @@ struct Args {
 fn main() {
     let args = Args::parse();
     let code = std::fs::read_to_string(&args.file).expect("Failed to read the file.");
-    let prog = compile(&code);
+    let prog = match compile(&code) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+    };
     let offset = get_offset(&prog);
     if args.flush {
         unsafe_run::<true>(prog, args.length, offset);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
-mod brainfuck;
-use brainfuck::{compile, unsafe_run, get_offset};
+use bropt::brainfuck::{compile, unsafe_run, get_offset};
 use clap::Parser;
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
## Summary
- build bropt as a cdylib and expose a C-compatible `bropt_run` entry point
- provide a simple `bropt.py` wrapper to run brainfuck code from Python
- adjust main binary to use the shared library module

## Testing
- `cargo test`
- `cargo build --release`


------
https://chatgpt.com/codex/tasks/task_e_689f34aa64108331a94db5b9694e8639