### PR TITLE
Add Python interface with runtime panic handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bropt"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "bropt"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
-pyo3 = { version = "0.21.2", features = ["extension-module"] }
+pyo3 = { version = "0.25.1", features = ["extension-module"] }
 
 [profile.dev]
 overflow-checks = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,12 @@ name = "bropt"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 clap = { version = "4.5.37", features = ["derive"] }
+pyo3 = { version = "0.21.2", features = ["extension-module"] }
 
 [profile.dev]
 overflow-checks = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "bropt"
+version = "0.1.0"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Rust",
+]

--- a/src/brainfuck.rs
+++ b/src/brainfuck.rs
@@ -660,11 +660,12 @@ pub fn run<const FLUSH: bool>(prog: Vec<Inst>, length: usize) {
 
 #[allow(dead_code)]
 #[inline]
-pub fn run_with_state(prog: Vec<Inst>, length: usize) -> (Vec<u8>, Vec<u8>, usize) {
+pub fn run_with_state(prog: Vec<Inst>, length: usize, input: &[u8]) -> (Vec<u8>, Vec<u8>, usize) {
     let mut data = vec![0u8; length];
     let mut dp: usize = 0;
     let mut ip: usize = 0;
     let mut output = Vec::new();
+    let mut in_idx = 0usize;
     while ip < prog.len() {
         let Inst {
             cmd,
@@ -683,9 +684,9 @@ pub fn run_with_state(prog: Vec<Inst>, length: usize) -> (Vec<u8>, Vec<u8>, usiz
             dp = (dp as isize + *delta as isize) as usize;
         } else if *cmd == InstType::Input {
             dp = (dp as isize + *arg as isize) as usize;
-            let mut buf = [0u8];
-            if io::stdin().read_exact(&mut buf).is_ok() {
-                data[dp] = buf[0];
+            if in_idx < input.len() {
+                data[dp] = input[in_idx];
+                in_idx += 1;
             } else {
                 data[dp] = 0u8;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,47 @@
+pub mod brainfuck;
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+use brainfuck::{compile as bf_compile, run_to_bytes, Inst};
+
+fn panic_to_pyerr(err: Box<dyn std::any::Any + Send>) -> PyErr {
+    if let Some(s) = err.downcast_ref::<&str>() {
+        PyRuntimeError::new_err(*s)
+    } else if let Some(s) = err.downcast_ref::<String>() {
+        PyRuntimeError::new_err(s.clone())
+    } else {
+        PyRuntimeError::new_err("panic occurred")
+    }
+}
+
+#[pyclass]
+pub struct Program {
+    prog: Vec<Inst>,
+}
+
+#[pymethods]
+impl Program {
+    pub fn run(&self, py: Python<'_>, length: usize) -> PyResult<Py<PyBytes>> {
+        let prog = self.prog.clone();
+        match std::panic::catch_unwind(|| run_to_bytes(prog, length)) {
+            Ok(out) => Ok(PyBytes::new(py, &out).into()),
+            Err(err) => Err(panic_to_pyerr(err)),
+        }
+    }
+}
+
+#[pyfunction]
+fn compile(code: &str) -> PyResult<Program> {
+    match std::panic::catch_unwind(|| bf_compile(code)) {
+        Ok(prog) => Ok(Program { prog }),
+        Err(err) => Err(panic_to_pyerr(err)),
+    }
+}
+
+#[pymodule]
+fn bropt(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(compile, m)?)?;
+    m.add_class::<Program>()?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ impl Program {
         &self,
         py: Python<'_>,
         length: usize,
-        input: Option<&PyAny>,
+        input: Option<&Bound<'_, PyAny>>
     ) -> PyResult<(Py<PyByteArray>, Py<PyByteArray>, usize)> {
         let prog = self.prog.clone();
         let input_bytes = match input {
@@ -61,7 +61,7 @@ fn compile(code: &str) -> PyResult<Program> {
 }
 
 #[pymodule]
-fn bropt(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn bropt(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compile, m)?)?;
     m.add_class::<Program>()?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod brainfuck;
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use pyo3::types::PyBytes;
 
 use brainfuck::{Inst, compile as bf_compile, run_with_state};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,13 +22,18 @@ pub struct Program {
 
 #[pymethods]
 impl Program {
+    #[pyo3(signature = (length, input=None))]
     pub fn run(
         &self,
         py: Python<'_>,
         length: usize,
+        input: Option<&PyBytes>,
     ) -> PyResult<(Py<PyBytes>, Py<PyBytes>, usize)> {
         let prog = self.prog.clone();
-        match std::panic::catch_unwind(|| run_with_state(prog, length)) {
+        let input_bytes = input
+            .map(|b| b.as_bytes().to_vec())
+            .unwrap_or_else(Vec::new);
+        match std::panic::catch_unwind(|| run_with_state(prog, length, &input_bytes)) {
             Ok((out, data, ptr)) => Ok((
                 PyBytes::new(py, &out).into(),
                 PyBytes::new(py, &data).into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
-mod brainfuck;
-use brainfuck::{compile, unsafe_run, get_offset};
+use bropt::brainfuck::{compile, unsafe_run, get_offset};
 use clap::Parser;
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
## Summary
- expose `bropt` as a Python module with `compile` and `Program.run`
- return program output as bytes and surface panics as `RuntimeError`
- update crate to build as `cdylib` and include `pyo3`

## Testing
- `cargo test` *(fails: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_689f60c121288331946c0cef1597da83